### PR TITLE
Unicode-based split of words and graphemes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,15 +3,6 @@
 version = 3
 
 [[package]]
-name = "aho-corasick"
-version = "0.7.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e37cfd5e7657ada45f742d6e99ca5788580b5c529dc78faf11ece6dc702656f"
-dependencies = [
- "memchr",
-]
-
-[[package]]
 name = "ansi_term"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -84,12 +75,11 @@ dependencies = [
 
 [[package]]
 name = "fsrx"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "ansi_term",
  "atty",
  "clap",
- "regex",
  "unicode-segmentation",
 ]
 
@@ -135,12 +125,6 @@ name = "libc"
 version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "349d5a591cd28b49e1d1037471617a32ddcda5731b99419008085f72d5a53836"
-
-[[package]]
-name = "memchr"
-version = "2.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
 
 [[package]]
 name = "os_str_bytes"
@@ -189,23 +173,6 @@ checksum = "a1feb54ed693b93a84e14094943b84b7c4eae204c512b7ccb95ab0c66d278ad1"
 dependencies = [
  "proc-macro2",
 ]
-
-[[package]]
-name = "regex"
-version = "1.5.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d83f127d94bdbcda4c8cc2e50f6f84f4b611f69c902699ca385a39c3a75f9ff1"
-dependencies = [
- "aho-corasick",
- "memchr",
- "regex-syntax",
-]
-
-[[package]]
-name = "regex-syntax"
-version = "0.6.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49b3de9ec5dc0a3417da371aab17d729997c15010e7fd24ff707773a33bddb64"
 
 [[package]]
 name = "strsim"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fsrx"
-version = "1.0.0"
+version = "1.0.1"
 description = "📚 flow state reading in the terminal"
 edition = "2021"
 readme = "README.md"
@@ -13,7 +13,6 @@ keywords = ["reading", "utility", "terminal", "cli", "fast" ]
 
 [dependencies]
 ansi_term = "0.12.1"
-regex = "1.5.6"
 unicode-segmentation = "1.9.0"
 clap = { version = "3.1.18", features = ["derive"] }
 atty = "0.2.14"


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**: 
- Inputs with non-latin alphabets are now processed correctly.

<!-- Why are these changes necessary? -->

**Why**:
- The original regex `[\w\\']+` only matches latin alphabets, thus non-latin inputs were not processed at all.
- The `&str.len()` is not always the same as the length of the Unicode graphemes, and indices in `style_substr` were calculated wrongly for multibyte characters.

<!-- How were these changes implemented? -->

**How**:
- Changed the word-split algorithm from regex to `unicode_word_indices`
- Changed the character indexing from `&str` slice to `UnicodeSegmentation::graphemes`

**Tests**:
- English
`echo 'The Quick Brown Fox Jumps Over The Lazy Dog' | fsrx`
- French
`echo "Le cœur déçu mais l'âme plutôt naïve, Louÿs rêva de crapaüter en canoë au-delà des îles, près du mälström où brûlent les novæ" | fsrx`
- Korean
`echo '키스의 고유 조건은 입술끼리 만나야 하고 특별한 기술은 필요치 않다.' | fsrx`

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] `Allow edits from maintainers` option checked
- [x] Branch name is prefixed with `[your_username]/` (ex. `coloradocolby/featureX`)
- [x] Documentation added
- [x] Tests added
- [x] No failing actions
- [x] Merge ready
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->

**Caveat**:
- I comfirmed that languages putting spaces between words are processed quite similarly to English. However, it seems that `fsrx`'s algorithm (and Bionic Reading) cannot be applicable to some Asian languages that do not use spaces (such as Japanese and Chinese.)
